### PR TITLE
Final (?) round of changes

### DIFF
--- a/P0534R1.tex
+++ b/P0534R1.tex
@@ -42,8 +42,9 @@
 \small
 \begin{tabbing}
     Document number: \= P0534R1\\
-    Date:            \> 2017-06-17\\
+    Date:            \> 2017-06-18\\
     Reply-to:        \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
+    Authors:         \> Oliver Kowalke (oliver.kowalke@gmail.com), Nat Goodspeed (nat@lindenlab.com)\\
     Audience:        \> SG1/LEWG\\
 \end{tabbing}
 
@@ -120,6 +121,10 @@ implementation,\cite{bcontext} maintained by a single author, supports a
 small set of current platforms available to that author. Should \cc be
 integrated into the Standard, it will become universally available.\\
 
+Moreover, correct support for certain platforms might involve undocumented
+complexity. The runtime vendor is best positioned to implement the specified
+functionality.\\
+
 Compiler awareness of this facility could enable certain optimizations as
 well:
 
@@ -148,6 +153,7 @@ Changes since P0534R0:
         \item stack unwinding now explicitly requires specific \cpp{unwind\_exception} 
               exception
     \end{itemize}
+    \item added example use cases
     \item \cc compared with \uc and \lj
     \item why \cc is a low-level implementation
     \item details of stack destruction

--- a/code/deepstack.cpp
+++ b/code/deepstack.cpp
@@ -1,75 +1,50 @@
-#include <iostream>
-#include <boost/context/continuation.hpp>
-
-// Launch this context early in the thread as a service
-// used by deep_call()
-boost::context::continuation deep_stack(boost::context::continuation&& client) {
-    std::cout << "entering   deep_stack()" << std::endl;
-    try {
-        for (;;) {
-            // In effect, this context is a little server,
-            // running invoke_ontop_arg functions that
-            // need a deep stack and then context-
-            // switching back to whatever invoked them.
-            // Because of this infinite loop, it won't
-            // terminate voluntarily: we'll destroy it
-            // while it's suspended.
-            std::cout << "spinning   deep_stack()" << std::endl;
-            client = client.resume();
-            // if we were passed a std::function object
-            if (client.data_available()) {
-                // retrieve it
-                std::function<void()> func =
-                    client.get_data<std::function<void()>>();
-                // and call it
-                func();
-            }
+// launch this context early in the thread as a service used by deep_call()
+std::continuation deep_stack(std::continuation&& client) {
+    for (;;) {
+        // In effect, this context is a little server, running resume_with()
+        // functions that need a deep stack and then context-switching back to
+        // whatever invoked them. Because of this infinite loop, it won't
+        // terminate voluntarily: we'll destroy it while it's suspended.
+        client = client.resume();
+        // if we were passed a std::function object
+        if (client.data_available()) {
+            // retrieve it
+            std::function<void()> func =
+                client.get_data<std::function<void()>>();
+            // and call it
+            func();
         }
-        std::cout << "exiting    deep_stack()" << std::endl;
-        return std::move(client);
-    } catch (...) {
-        std::cout << "destroying deep_stack()" << std::endl;
-        throw;
     }
+    return std::move(client);
 }
 
-// deep_call() continually updates this continuation as
-// the way to run code in the context of deep_stack()
-boost::context::continuation deep_stack_cont;
-
-// this function can be called from a context with a
-// shallow stack to run some non-suspending function in
+// deep_call() continually updates this continuation as the way to run code in
 // the context of deep_stack()
+std::continuation deep_stack_cont;
+
+// this function can be called from a context with a shallow stack to run some
+// non-suspending function in the context of deep_stack()
 void deep_call(std::function<void()> const& func) {
-    std::cout << "entering   deep_call()" << std::endl;
     deep_stack_cont = deep_stack_cont.resume(func);
-    std::cout << "exiting    deep_call()" << std::endl;
 }
 
-// this is an example of a context with a shallow stack...
-// we don't actually give it a shallow stack because we do
-// want to see its std::cout output
-boost::context::continuation shallow_stack(boost::context::continuation&& caller) {
-    std::cout << "entering   shallow_stack()" << std::endl;
-    std::cout << "calling    deep_call()" << std::endl;
+// this is an example of a context with a shallow stack
+std::continuation shallow_stack(std::continuation&& caller) {
+    // pretend that emitting std::cout requires arbitrary stack depth
     deep_call([](){ std::cout << "Hello from deep_stack!" << std::endl; });
-    std::cout << "calling    deep_call() again" << std::endl;
     deep_call([](){ std::cout << "Another visit to deep_stack" << std::endl; });
-    std::cout << "exiting    shallow_stack()" << std::endl;
     return std::move(caller);
 }
 
 // main() simply launches the deep_stack() resource context, then runs
 // shallow_stack() as an example of a consumer
 int main() {
-    std::cout << "launching  deep_stack()" << std::endl;
-    // Because deep_stack() simply loops on switching back
-    // to its most recent invoker, this call should bounce
-    // right back here.
-    deep_stack_cont = boost::context::callcc(deep_stack);
-    std::cout << "launched   deep_stack()" << std::endl;
-    std::cout << "launching  shallow_stack()" << std::endl;
-    boost::context::callcc(shallow_stack);
-    std::cout << "back from  shallow_stack()" << std::endl;
+    // Launch the deep_stack() context. Pretend we're passing a StackAllocator
+    // with a size "big enough for whatever." Since the first thing
+    // deep_stack() does is to switch back to its invoker, this call should
+    // bounce right back here.
+    deep_stack_cont = std::callcc(deep_stack);
+    // pretend we're passing a StackAllocator with a very small stack size
+    std::callcc(shallow_stack);
     return 0;
 }

--- a/notes.tex
+++ b/notes.tex
@@ -12,6 +12,7 @@ kinds of ``lightweight execution agents'' should interact.
 
 does not interfere with \cc and can be used as usual (\cc triggers the context
 switch at its invocation).\\
+
 Of course, depending on the calling convention, some micro-processor registers,
 dedicated to SIMD, might be preserved and restored too
 \footnote{\emph{MS Windows x64} calling convention}.
@@ -20,8 +21,8 @@ dedicated to SIMD, might be preserved and restored too
 \uabschnitt{TLS}
 
 \cc is TLS-agnostic - best practice related to TLS applies to \cc too.\\
-As shown in \nameref{mechanism}, \cc only preserves and restores
-micro-processor registers at its invocation.
+
+\cc only preserves and restores micro-processor registers at its invocation.
 
 
 \uabschnitt{Migration between threads}

--- a/use_cases.tex
+++ b/use_cases.tex
@@ -60,7 +60,7 @@ The Boost.Fiber library\cite{bfiber} is an implementation of fibers based on
 the \cpp{callcc()} implementation in Boost.Context.\cite{bcontext}
 
 \uabschnitt{Why not use \cpp{std::thread}s?}
-There are two reasons to prefer userland threads over \cpp{std::thread}s:
+There are a few reasons to prefer userland threads over \cpp{std::thread}s:
 \begin{description}
   \item[Performance:] The Skynet benchmark results\cite{bfiberperf} illustrate
   that userland context-switching can be three orders of magnitude faster than
@@ -71,6 +71,8 @@ There are two reasons to prefer userland threads over \cpp{std::thread}s:
   reasonable (even when possible) to launch that many kernel threads.
   Kernel-mediated context-switching overhead starts to overwhelm the
   processor.
+  \item[Thread safety:] Refactoring an existing chain of callbacks into
+  userland threads is guaranteed to introduce no new data races.
 \end{description}
 
 \uabschnitt{Why not use \coawait\cite{N4649}?}
@@ -253,7 +255,10 @@ A few examples of such cases:\\
 
   The input iterator corresponding to the \cpp{pull\_type} coroutine can then
   be dereferenced as desired. Every time a new item is requested, the Karma
-  generator is resumed to produce it.
+  generator is resumed to produce it.\\
+
+  Attempting to use \coawait for this would require rewriting the Boost.Spirit
+  Karma library.
 \end{description}
 
 \uabschnitt{Stackful coroutines built on \cpp{callcc()}}


### PR DESCRIPTION
As I said in email, in deepstack.cpp in the proposal I'd like to use the std:: namespace for callcc() and continuation. I removed the std::cout output because it doesn't help the reader of the proposal, and it's *much* shorter without that. I also removed the outer try/catch from deep_stack() because, without the final std::cout, there's no point: all that's left is `throw;`

I added a note about undocumented complexity on particular platforms, as you suggested.

I added myself as co-author. I added a few more thoughts.