### PR TITLE
Finish removing references to data-transfer feature.

### DIFF
--- a/P0534R3.tex
+++ b/P0534R3.tex
@@ -109,10 +109,7 @@ Consider the following bullets from P0559R0:\cite{P0559R0}
 
 The proposed \cc facility is intended to be foundational. While of course
 application coders are free to use the \cc API, its real promise is in
-supporting higher-level abstractions.\\
-
-This proposal describes the basic \cc facility, presents some illustrative use
-cases and explains why the API is set at its present level.
+supporting higher-level abstractions.
 
 \abschnitt{Why should \cc be standardized?}
 
@@ -132,7 +129,7 @@ well:
   \item The compiler might be able to analyze the code to be launched on a new
     \cc context and determine an optimal stack size for that context.
   \item The compiler might be able to determine that not all registers need be
-    preserved across a context switch.
+    preserved across a particular context switch.
   \item For certain use cases, the compiler might be able to optimize away
     context-switching altogether. Promising work has been done in this area
     for the \coawait facility.\cite{N4649}

--- a/P0534R3.tex
+++ b/P0534R3.tex
@@ -42,7 +42,7 @@
 \small
 \begin{tabbing}
     Document number: \= P0534R3\\
-    Date:            \> 2017-08-01\\
+    Date:            \> 2017-08-29\\
     Reply-to:        \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
     Authors:         \> Oliver Kowalke (oliver.kowalke@gmail.com), Nat Goodspeed (nat@lindenlab.com)\\
     Audience:        \> LEWG\\

--- a/api.tex
+++ b/api.tex
@@ -17,7 +17,7 @@ constructs new execution context\\
 
     \midrule
 
-    \cpp{continuation(continuation&& other)} & (2)\\
+    \cpp{continuation(continuation&& other) noexcept} & (2)\\
 
     \midrule
 
@@ -86,7 +86,7 @@ moves the continuation object\\
 \begin{tabular}{ l l }
     \midrule
 
-    \cpp{continuation& operator=(continuation&& other)} & (1)\\
+    \cpp{continuation& operator=(continuation&& other) noexcept} & (1)\\
 
     \midrule
 
@@ -199,7 +199,8 @@ returned by that \resume call. This helps to avoid inadvertent calls to \resume
 on the old, invalidated instance.
 \newline
 An injected function \cpp{fn()} must accept \cpp{std::continuation&&} and
-return void (return value is discarded).
+return \cont. The returned \cont instance is, in turn, used as the return
+value for the suspended function: \callcc, \resume or \resumewith.
 
 
 \subparagraph*{operator bool}

--- a/api.tex
+++ b/api.tex
@@ -136,7 +136,7 @@ resumes a continuation\\
 
 {\bfseries Parameters}
 \begin{description}
-    \item[fn] function invoked ontop of resumed continuation\\
+    \item[fn] function injected into resumed continuation\\
 \end{description}
 
 {\bfseries Return value}
@@ -188,8 +188,7 @@ A suspended \cpp{continuation} can be destroyed. Its resources will be cleaned
 up at that time.
 \newline
 The returned \cpp{continuation} indicates whether the suspended context has
-terminated (returned from \entryfn) via \opbool. If the returned
-\cpp{continuation} has terminated, no data may be retrieved.
+terminated (returned from \entryfn) via \opbool.
 \newline
 Because \resume invalidates the instance on which it is called, \emph{no valid
 \cont instance ever represents the currently-running context.}
@@ -201,11 +200,6 @@ on the old, invalidated instance.
 \newline
 An injected function \cpp{fn()} must accept \cpp{std::continuation&&} and
 return void (return value is discarded).
-
-Neither an injected function \cpp{fn()}, nor any function it calls, may
-perform a context switch back to the context that called \resumewith --
-whether directly, or indirectly via other contexts. \cpp{fn()} \emph{must}
-return (or throw an exception) before \resumewith returns.
 
 
 \subparagraph*{operator bool}

--- a/callcc.tex
+++ b/callcc.tex
@@ -47,8 +47,8 @@ Data can be transfered between two continuations via global pointer, calling
 wrappers (like \cpp{std::bind}) or lambda captures.
 \cppf{fibonacci}
 
-Variable \cpp{a} is used to transfer the computed fibonnaci number and captured
-as reference by the lmbda.\\
+Variable \cpp{a} is captured by reference by the lambda and used to transfer
+the computed fibonnaci number.\\
 The invocation of \callcc at (0) immediately enters the lambda, passing the
 \currcont. The lambda calculates the fibonacci number using local variables
 \cpp{a}, \cpp{b} and \cpp{next}. The calculated fibonacci number is stored in

--- a/code/continuation.cpp
+++ b/code/continuation.cpp
@@ -21,13 +21,3 @@ public:
     bool operator>=( continuation const& other) const noexcept;
     void swap( continuation & other) noexcept;
 };
-
-template< typename Fn >
-continuation callcc( Fn &&);
-
-template< typename StackAlloc, typename Fn >
-continuation callcc( std::allocator_arg_t, StackAlloc, Fn &&);
-
-void unwind_context( continuation && cont);
-
-struct unwind_exception{};

--- a/code/deepstack.cpp
+++ b/code/deepstack.cpp
@@ -6,14 +6,6 @@ std::continuation deep_stack(std::continuation&& client) {
         // invoked it. Because of this infinite loop, it won't terminate
         // voluntarily: we'll destroy it while it's suspended.
         client = client.resume();
-        // if we were passed a std::function object
-        if (client.data_available()) {
-            // retrieve it
-            std::function<void()> func =
-                client.get_data<std::function<void()>>();
-            // and call it
-            func();
-        }
     }
     return std::move(client);
 }
@@ -24,8 +16,17 @@ std::continuation deep_stack_cont;
 
 // this function can be called from a context with a shallow stack to run some
 // non-suspending function in the context of deep_stack()
-void deep_call(std::function<void()> const& func) {
-    deep_stack_cont = deep_stack_cont.resume(func);
+template <typename Fn>
+void deep_call(Fn&& fn) {
+    // This resume_with() call runs the lambda on the deep_stack() context.
+    // The lambda simply calls the passed fn, then returns to the loop in
+    // deep_stack(), which context-switches back to return from resume_with().
+    // Finally we update the canonical deep_stack_cont for the next usage.
+    deep_stack_cont = deep_stack_cont.resume_with(
+        [auto fn=std::forward<Fn>(fn)](std::continuation&& caller){
+            fn();
+            return std::move(caller);
+        });
 }
 
 // this is an example of a context with a shallow stack

--- a/code/ontop.cpp
+++ b/code/ontop.cpp
@@ -21,15 +21,16 @@ data+=1;
 f_ct=  // (13)
     f_ct.resume_with([&data](std::continuation && mc){  // (8)
                         std::cout << "f2: entered: " << data << std::endl;
-                        data=-1;  // (9)
-                        return std::move( c);
+                        data=-1;
+                        return std::move( mc);  // (9)
                 });
 std::cout << "f1: returned third time" << std::endl;
 
 output:
-    f: entered first time: 1
-    f: returned first time: 2
-    f: entered second time: 3
-    f: returned second time: 4
-    g: entered: 5
-    f: entered third time: -1
+    f1: entered first time: 0
+    f1: returned first time: 1
+    f1: entered second time: 2
+    f1: returned second time: 3
+    f2: entered: 4
+    f1: entered third time: -1
+    f1: returned third time

--- a/design.tex
+++ b/design.tex
@@ -128,52 +128,43 @@ the \entryfn's \cpp{catch} clause can return that continuation.
 
 Sometimes it is useful to inject a new function (for instance, to throw an
 exception) into a suspended context. For this purpose you may call
-\cpp{resume\_with(Fn && fn)}, passing:
-
-\begin{itemize}
-    \item the function \cpp{fn()} to execute
-    \item additional data \cpp{args} to be retrieved by \cpp{fn()}.
-\end{itemize}
+\cpp{resume\_with(Fn && fn)}, passing the function \cpp{fn()} to execute.
 
 Let's say that the context represented by the \cont instance \cpp{ctx} has
-suspended in a function \cpp{suspender()}. You intend to inject function
-\cpp{fn()} into context \cpp{ctx} as if \cpp{suspender()} had directly called
-\cpp{fn()} at the point where it suspended.\\
+called a function \cpp{suspender()}, which has called \contresume and is now
+suspended. You intend to inject function \cpp{fn()} into context \cpp{ctx} as
+if \cpp{suspender()}'s \suspend call had directly called \cpp{fn()}.\\
 
 Like an \entryfn passed to \callcc, \cpp{fn()} must accept
-\cpp{std::continuation&&}. However, instead of returning \cont, \cpp{fn()} must
-return a type corresponding to the \cpp{args} passed to the \resumewith call.
+\cpp{std::continuation&&} and return \cont. The \cont instance returned
+by \cpp{fn()} will, in turn, be returned to \cpp{suspender()} by its \suspend
+call.
 
-\begin{itemize}
-    \item If you call \cpp{ctx.resume\_with(fn)}, the return type of \cpp{fn()}
-          is void.
-\end{itemize}
+Suppose that code running on the program's main context
+calls \cpp{std::callcc()}, thereby entering the first lambda shown below. This
+is the point at which \cpp{mc} is synthesized and passed into the lambda at (0).
 
-Suppose that code running on the program's main context calls \cpp{std::callcc(f)},
-thereby entering \cpp{f()}. This is the point at which \cpp{mc} is synthesized
-and passed into \cpp{f()}, as illustrated below.\\
+Suppose further that after doing some work ((1) through (5)), the lambda
+calls \cpp{mc.resume()}, thereby switching back to the main context. The
+lambda remains suspended in the call to \cpp{mc.resume()} at (6).
 
-Suppose further that after doing some work, \cpp{f()} calls \cpp{mc.resume()},
-thereby switching back to the main context. \cpp{f()} remains suspended
-in the call to \cpp{mc.resume()}.\\
+At (8) the main context calls \cpp{f\_ct.resume\_with()} where the passed
+lambda accepts \cpp{continuation &&}. That new lambda is entered in the
+context of the suspended lambda. It is as if the \cpp{mc.resume()} call at (6)
+directly called the second lambda.\\
 
-At this point the main context calls \cpp{f\_ct.resume\_with(g)}
-where \cpp{g()} is declared as \cpp{int g(continuation &&)}. \cpp{g()} is
-entered in the context of \cpp{f()}. It is as if \cpp{f()}'s call
-to \cpp{mc.resume()} directly called \cpp{g()}.\\
-
-Function \cpp{g()} has almost the same range of possibilities as any function
-called on \cpp{f()}'s context. Its special invocation matters when control
-leaves it in either of two ways:
+The function passed to \resumewith has almost the same range of possibilities
+as any function called on the context represented by \cpp{f\_ct}. Its special
+invocation matters when control leaves it in either of two ways:
 
 \begin{enumerate}
-  \item If \cpp{g()} throws an exception, that exception unwinds all previous
-        stack entries in that context (such as \cpp{f()}'s) as well, back to a
-        matching \cpp{catch} clause.\footnote{As stated in
-        \nameref{subsec:exceptions}, if there is no matching \cpp{catch} clause
-        in that context, \cpp{std::terminate()} is called.}
-  \item If \cpp{g()} returns, its return value provides data for \cpp{f()}'s
-        suspended \cpp{mc.resume()} call.
+  \item If it throws an exception, that exception unwinds all previous stack
+        entries in that context (such as the first lambda's) as well, back to
+        a matching \cpp{catch} clause.\footnote{As stated
+        in \nameref{subsec:exceptions}, if there is no matching \cpp{catch}
+        clause in that context, \cpp{std::terminate()} is called.}
+  \item If the function returns, the returned \cont instance is returned by
+        the suspended \cpp{mc.resume()} (or \callcc, or \resumewith) call.
 \end{enumerate}
 
 \cppf{ontop}
@@ -181,20 +172,15 @@ leaves it in either of two ways:
 Control passes from (0) to (1) to (2), and so on.\\
 
 The \cpp{f\_ct.resume\_with(<lambda>)} call at (8) passes control
-to \cpp{g()} on the context of \cpp{f()}.\\
+to the second lamba on the context of the first lambda.\\
 
-The \cpp{return} statement at (9) causes the \resume call at (6) to return,
-executing the assignment at (10). The \cpp{int} returned by \cpp{g()} is
-accessed at (11).\\
+As usual, \resumewith synthesizes a \cont instance representing the calling
+context, passed into the lambda as \cpp{mc}. This particular lambda
+returns \cpp{mc} unchanged at (9); thus that \cpp{mc} instance is returned by
+the \resume call at (6) and assigned at (10).\\
 
-Finally, \cpp{f()} returns its own \cpp{mc} variable, switching back to the main
-context.\\
-
-There is one restriction on a function \cpp{fn()} passed to \resumewith:
-neither \cpp{fn()}, nor any function it calls, may perform a context switch
-back to the context that called \resumewith -- whether directly, or indirectly
-via other contexts. \cpp{fn()} \emph{must} return (or throw an exception)
-before \resumewith returns.
+Finally, the first lambda returns at (12) the \cpp{mc} variable updated at
+(10), switching back to the main context.
 
 
 \uabschnitt{\callcc immediately enters new context}
@@ -222,10 +208,6 @@ any context-switch operation. Indeed, it does not yet have a stack frame.\\
 
 Should \cpp{injected\_function()} \emph{become} the \entryfn
 for \cpp{newcontext}, displacing \cpp{entry\_function()} entirely?\\
-
-That would encounter signature problems. The \entryfn invoked by \callcc
-\emph{must} return a \cont. Yet the \cpp{fn} passed to \resumewith returns --
-not a \cont -- but arbitrary data to be retrieved by the suspended context!\\
 
 With the present API, to quickly resume the caller's context rather than
 prioritizing the new context, the \entryfn passed to \callcc can immediately

--- a/design.tex
+++ b/design.tex
@@ -133,12 +133,11 @@ exception) into a suspended context. For this purpose you may call
 Let's say that the context represented by the \cont instance \cpp{ctx} has
 called a function \cpp{suspender()}, which has called \contresume and is now
 suspended. You intend to inject function \cpp{fn()} into context \cpp{ctx} as
-if \cpp{suspender()}'s \suspend call had directly called \cpp{fn()}.\\
+if \cpp{suspender()}'s \resume call had directly called \cpp{fn()}.\\
 
 Like an \entryfn passed to \callcc, \cpp{fn()} must accept
 \cpp{std::continuation&&} and return \cont. The \cont instance returned
-by \cpp{fn()} will, in turn, be returned to \cpp{suspender()} by its \suspend
-call.
+by \cpp{fn()} will, in turn, be returned to \cpp{suspender()} by \resume.
 
 Suppose that code running on the program's main context
 calls \cpp{std::callcc()}, thereby entering the first lambda shown below. This


### PR DESCRIPTION
Also remove restriction preventing context-switching from a `resume_with()` function. Describe the new `resume_with()` function signature and the role of the `continuation` returned by such a function.