### PR TITLE
Further updates for pre-Albuquerque mailing.

### DIFF
--- a/P0534R3.tex
+++ b/P0534R3.tex
@@ -42,7 +42,7 @@
 \small
 \begin{tabbing}
     Document number: \= P0534R3\\
-    Date:            \> 2017-08-29\\
+    Date:            \> 2017-10-15\\
     Reply-to:        \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
     Authors:         \> Oliver Kowalke (oliver.kowalke@gmail.com), Nat Goodspeed (nat@lindenlab.com)\\
     Audience:        \> LEWG\\
@@ -59,8 +59,10 @@
 \abschnitt{Abstract}
 This document proposes a C++ equivalent to the well-known concept
 \bfs{call-with-current-continuation} (abbreviated \bfs{call/cc}). This
-facility permits a program written in portable C++ to subdivide processing into
-distinct \bfs{contexts:} units smaller than a thread.\\
+facility permits a program written in portable C++ to delegate processing to
+distinct lightweight execution agents nested within a thread. Within this
+proposal, the terms \bfs{context}, \bfs{execution context} and \bfs{context of
+execution} all refer interchangeably to an execution agent of this form.\\
 
 Within this proposal, the unadorned term ``thread'' means a \cpp{std::thread}
 (or \bfs{kernel thread}).
@@ -83,6 +85,11 @@ This has a couple of important implications:
   one context suspends and another resumes, is \bfs{context-switching.}
 \item There are no data races between contexts running on the same thread.
 \end{itemize}
+
+It may be desirable to invent a less overloaded term for lightweight stackful
+mutually-exclusive execution agents nested within a thread. The term
+``context'' is used for now because ``context-switching'' is a well-established
+term of art.\\
 
 The kind of context-switching presented in this proposal is called
 \bfs{stackful} because each context requires some implementation of the C++
@@ -141,7 +148,7 @@ This document supersedes P0534R2.\cite{P0534R2}\\
 Changes since P0534R2:
 
 \begin{itemize}
-    \item simplier API (transfer of data discarded)
+    \item simpler API (transfer of data discarded)
 \end{itemize}
 
 \input{continuations}

--- a/callcc.tex
+++ b/callcc.tex
@@ -43,7 +43,7 @@ while \resume returns control back to the continuation saved in \cpp{*this}.\\
 
 The presented code prints out \cpp{"foo"} and \cpp{"bar"} in a endless loop.\\
 
-Data can be transfered between two continuations via global pointer, calling
+Data can be transferred between two continuations via global pointer, calling
 wrappers (like \cpp{std::bind}) or lambda captures.
 \cppf{fibonacci}
 

--- a/cc_vs_uc.tex
+++ b/cc_vs_uc.tex
@@ -1,4 +1,5 @@
-\abschnitt{Why \cc should be preferred over \uc or \lj}
+\newpage
+\abschnitt{Why \cc should be preferred over \uc}
 
 \uabschnitt{stack represents the continuation}
 
@@ -13,7 +14,6 @@ execution context (the content of the registers).
     \item suspended execution context is passed as continuation (parameter) 
         to the resume operation
     \item no need for a global pointer that points to the current execution context
-    \item data are transferred through a function call, no need for a global pointer
     \item \main and each thread's \entryfn integrate seamlessly with \cc
         because the stack of \main, or the thread, already represents the continuation of
         that context
@@ -32,13 +32,21 @@ A instance of \cont contains the stack address of a suspended execution.
         context
     \item prevents accidentally resuming an execution context that has already
         terminated (computation has finished)
-    \item manages lifespan of an explicitly-allocated stack: the stack gets
+    \item manages lifespan of an explicitly-allocated stack: the stack is
         deallocated when \cont goes out of scope
-    \item context switch and data transfer via one function call
 \end{itemize}
 
 Of course a \uc-like standard API would be possible, but in C++ we can do much
 better with very little abstraction cost.
+
+\cont stores a pointer.
+
+\contresume:
+\begin{itemize}
+    \item optionally tests for \cpp{nullptr}
+    \item stores \cpp{nullptr} to invalidate \cpp{*this}
+    \item calls assembly code for stack switch.
+\end{itemize}
 
 \uabschnitt{Disadvantages of \uc}
 
@@ -55,21 +63,4 @@ better with very little abstraction cost.
     \item does not prevent accidentally resuming an execution context that has already
         terminated (computation has finished)
     \item does not manage lifespan of an explicitly-allocated stack
-    \item context switch (\cpp{swapcontext}) does not transfer data (requires global pointer)
-\end{itemize}
-
-\uabschnitt{Disadvantages of \lj}
-
-\begin{itemize}
-    \item C99 defines \sj / \lj for non-local jumps
-    \item \lj is not required to preserve the current stack frame, therefore jumping into a function
-        which has exited (by return or by a different \lj higher up the stack) is undefined behavior:
-        only \lj up the call stack is allowed
-    \item does not prevent accidentally copying the stack
-    \item does not prevent accidentally resuming the running execution
-        context
-    \item does not prevent accidentally resuming an execution context that has already
-        terminated (computation has finished)
-    \item does not manage lifespan of an explicitly-allocated stack
-    \item context switch (\lj) does not transfer data (requires global pointer)
 \end{itemize}

--- a/design.tex
+++ b/design.tex
@@ -1,3 +1,4 @@
+\newpage
 \abschnitt{Design}\label{design}
 
 \uabschnitt{\callcc as a factory function}
@@ -20,7 +21,7 @@ typically be no larger than one pointer.
 
 \uabschnitt{Passing data}\label{subsec:data}
 
-Data can be transfered between two continuations via global pointer, calling
+Data can be transferred between two continuations via global pointer, calling
 wrappers (like \cpp{std::bind}) or lambda captures.
 \cppf{passing_lambda}
 
@@ -218,6 +219,27 @@ A more generic wrapper for that behavior could look something like this:
 Note that since \cpp{suspend\_immediately()} \emph{has} been entered, it
 is perfectly valid for the caller of \cpp{callcc\_deferred()} to
 call \resumewith on the returned \cont.
+
+
+\uabschnitt{\resume invalidates \cont}
+
+The academic literature distinguishes \emph{full continuations}
+from \emph{one-shot continuations.} A full continuation can be resumed
+multiple times, which would be not merely difficult to implement but
+semantically problematic in C++. The \cont proposed in this paper is a
+one-shot continuation. Its \resume method immediately invalidates the
+instance; that instance may no longer be resumed.\\
+
+Consider an implementation in which \cont stores a pointer into the
+processor's stack area. Once that \cont is resumed, the formerly-suspended
+function will eventually return, destroying its stack frame. Some other
+function will reuse the space in some completely different way. Or perhaps
+not; that location in the reserved stack area may remain uninitialized memory.\\
+
+It would be dramatically bad if that \cont instance retained the old pointer
+into the stack area, and consuming code mistakenly attempted to resume that
+same \cont again. Invalidating the \cont allows consuming code to detect the
+difference between a \cont that has not yet been resumed and one that has.
 
 
 \uabschnitt{Stack destruction}\label{subsec:destruction}

--- a/notes.tex
+++ b/notes.tex
@@ -19,7 +19,8 @@ dedicated to SIMD might be preserved and restored too
 
 \uabschnitt{TLS}
 
-\cc is TLS-agnostic - best practice related to TLS applies to \cc too.\\
+\cc is TLS-agnostic - best practice related to TLS applies to \cc too. (But
+see P0772R0.)\\
 
 \cc only preserves and restores micro-processor registers at its invocation.
 
@@ -28,3 +29,9 @@ dedicated to SIMD might be preserved and restored too
 
 is forbidden. A \cont may only be resumed on the \cpp{std::thread} on which it
 was launched.
+
+\uabschnitt{Relationship to executors}
+
+The \cc facility is intended to compose with executors. The authors envision
+an executor implementation that runs each passed work item on a \cc context.
+But neither \cc nor the executors proposal \emph{depend} on each other.

--- a/references.tex
+++ b/references.tex
@@ -2,18 +2,6 @@
 \addcontentsline{toc}{subsection}{References}
 \begin{thebibliography}{99}
 
-    \bibitem{N3708}
-        \href{http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3708.pdf}
-        {N3708: A proposal to add coroutines to the C++ standard library}
-
-    \bibitem{N3985}
-        \href{http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3985.pdf}
-        {N3985: A proposal to add coroutines to the C++ standard library}
-
-    \bibitem{N4045}
-        \href{http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4045.pdf}
-        {N4045: Library Foundations for Asynchronous Operations, Revision 2}
-
     \bibitem{N4649}
         \href{http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/n4649.pdf}
         {N4649: Working Draft, Technical Specification on C++ Extensions for Coroutines}
@@ -51,49 +39,5 @@
     \bibitem{bcontext}
         \href{http://www.boost.org/doc/libs/release/libs/context/doc/html/index.html}
         {Library \emph{Boost.Context}}
-
-    \bibitem{bcoroutine2}
-        \href{http://www.boost.org/doc/libs/release/libs/coroutine2/doc/html/index.html}
-        {Library \emph{Boost.Coroutine2}}
-
-    \bibitem{bcoroutinechaining}
-        \href{https://github.com/boostorg/coroutine/blob/master/example/asymmetric/chaining.cpp}
-        {\emph{Boost.Coroutine} example illustrating coroutine chaining}
-
-    \bibitem{bfiber}
-        \href{http://www.boost.org/doc/libs/release/libs/fiber/doc/html/index.html}
-        {Library \emph{Boost.Fiber}}
-
-    \bibitem{bfiberperf}
-        \href{http://www.boost.org/doc/libs/release/libs/fiber/doc/html/fiber/performance.html}
-        {\emph{Boost.Fiber} performance using Skynet microbenchmark}
-
-    \bibitem{bgraph}
-        \href{http://www.boost.org/doc/libs/release/libs/graph/doc/index.html}
-        {Library \emph{Boost.Graph}}
-
-    \bibitem{bgraphvisitor}
-        \href{http://www.boost.org/doc/libs/release/libs/graph/doc/visitor_concepts.html}
-        {\emph{Boost.Graph} Visitor Concepts}
-
-    \bibitem{bspirit}
-        \href{http://www.boost.org/doc/libs/release/libs/spirit/doc/html/index.html}
-        {Library \emph{Boost.Spirit}}
-
-    \bibitem{bspiritkarma}
-        \href{http://www.boost.org/doc/libs/release/libs/spirit/doc/html/spirit/karma.html}
-        {Library \emph{Boost.Spirit} Karma}
-
-    \bibitem{ohmy}
-        \href{https://www.youtube.com/watch?v=S6JpbmeuzNg}
-        {C++Now 2014 talk: Coroutines, Fibers and Threads, Oh My}
-
-    \bibitem{visitors}
-        \href{https://www.youtube.com/watch?v=3SvkWY7JSeY}
-        {C++Now 2016 talk: Pulling Visitors}
-
-    \bibitem{lazyspirit}
-        \href{http://boost.2283326.n4.nabble.com/Lazy-Spirit-Generators-td4691618.html}
-        {Boost developer mailing list: Lazy Spirit Generators?}
 
 \end{thebibliography}


### PR DESCRIPTION
Explain 'context' as a lightweight stackful mutually-exclusive execution agent
nested within a thread, but retain 'context' until we have a better term for
such execution agents.

Reinstate explanation of why std::continuation instead of an API more like
ucontext, but remove bullets about data transfer. Also remove comparison to
longjmp, as I doubt the committee would propose that as an alternative API.

Include an explicit Design section about why resume() invalidates *this.

Insert a reference to P0772R0 in the note about TLS.

Insert a note about relationship to executors.

Prune References.